### PR TITLE
This fixes the wrong @Iri annotation of the oa:prefix property for the TextQuoteSelector

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/selector/TextQuoteSelector.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/selector/TextQuoteSelector.java
@@ -34,7 +34,7 @@ public class TextQuoteSelector extends Selector {
      * A snippet of text that occurs immediately before the text which is being selected.
      * Each TextQuoteSelector should have exactly 1 oa:prefix property, and must not have more than 1.
      */
-    @Iri(OADM.PREFIX) private String prefix;
+    @Iri(OADM.TEXT_PREFIX) private String prefix;
 
     /**
      * Refers to http://www.w3.org/ns/oa#suffix


### PR DESCRIPTION
```
java.lang.IllegalArgumentException: Not a valid (absolute) URI: oa for entity with roles: [RDFObjectImpl, TextPositionSelector, T
extPositionQuoteSelector, TextQuoteSelector, ResourceObject]
        at org.openrdf.repository.object.composition.ClassResolver.resolveRoles(ClassResolver.java:175) ~[mico-extractor-named-entity-recognizer.jar:na]
```

as the @Iri annotation was pointing to the namespace prefix `oa` instead of the URI of the oa:prefix property.
