### PR TITLE
Updated get/setItems(..) Methods to use Set<> instead of lection<>

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/Choice.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/Choice.java
@@ -1,6 +1,6 @@
 package com.github.anno4j.model.impl.multiplicity;
 
-import java.util.Collection;
+import java.util.Set;
 
 import org.openrdf.annotations.Iri;
 import org.openrdf.repository.object.RDFObject;
@@ -11,10 +11,10 @@ import com.github.anno4j.model.namespaces.OADM;
 public interface Choice {
 
     @Iri(OADM.ITEM)
-    void setItems(Collection<RDFObject> items);
+    void setItems(Set<RDFObject> items);
     
     @Iri(OADM.ITEM)
-    Collection<RDFObject> getItems();
+    Set<RDFObject> getItems();
     
     void addItem(RDFObject item);
 

--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/ChoiceSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/ChoiceSupport.java
@@ -1,6 +1,5 @@
 package com.github.anno4j.model.impl.multiplicity;
 
-import java.util.Collection;
 import java.util.HashSet;
 
 import org.openrdf.repository.object.RDFObject;
@@ -16,12 +15,10 @@ public abstract class ChoiceSupport extends ResourceObjectSupport implements Cho
         if(item == null){
             return;
         }
-        Collection<RDFObject> items = getItems();
-        if(items == null){
-            items = new HashSet<>();
-            setItems(items);
+        if(this.getItems() == null){
+            this.setItems(new HashSet<RDFObject>());
         }
-        items.add(item);
+        this.getItems().add(item);
     }
     
 }

--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/Composite.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/Composite.java
@@ -1,6 +1,6 @@
 package com.github.anno4j.model.impl.multiplicity;
 
-import java.util.Collection;
+import java.util.Set;
 
 import org.openrdf.annotations.Iri;
 import org.openrdf.repository.object.RDFObject;
@@ -11,10 +11,10 @@ import com.github.anno4j.model.namespaces.OADM;
 public interface Composite {
 
     @Iri(OADM.ITEM)
-    void setItems(Collection<RDFObject> items);
+    void setItems(Set<RDFObject> items);
     
     @Iri(OADM.ITEM)
-    Collection<RDFObject> getItems();
+    Set<RDFObject> getItems();
     
     void addItem(RDFObject item);
     

--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/CompositeSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/CompositeSupport.java
@@ -1,6 +1,5 @@
 package com.github.anno4j.model.impl.multiplicity;
 
-import java.util.Collection;
 import java.util.HashSet;
 
 import org.openrdf.repository.object.RDFObject;
@@ -16,12 +15,10 @@ public abstract class CompositeSupport extends ResourceObjectSupport implements 
         if(item == null){
             return;
         }
-        Collection<RDFObject> items = getItems();
-        if(items == null){
-            items = new HashSet<>();
-            setItems(items);
+        if(this.getItems() == null){
+            this.setItems(new HashSet<RDFObject>());
         }
-        items.add(item);
+        this.getItems().add(item);
     }
     
 }


### PR DESCRIPTION
The reason is that Alibaba seams not to support collections. 

With collections the resulting RDF showed a Literal with the type HashSet instead of the RDFObjects stored in the collection. When defining the Methods with Set<RDFObject> everything works as expected.
