### PR TITLE
Fix for RemotePropertySet.remove() always returning true

### DIFF
--- a/anno4j-alibaba/object-repository/src/main/java/org/openrdf/repository/object/advisers/helpers/RemotePropertySet.java
+++ b/anno4j-alibaba/object-repository/src/main/java/org/openrdf/repository/object/advisers/helpers/RemotePropertySet.java
@@ -197,11 +197,13 @@ public class RemotePropertySet implements PropertySet, Set<Object> {
 	}
 
 	/**
-	 * This method always returns <code>true</code>
+	 * Removes the specified element from this set if it is present.
 	 * 
-	 * @return <code>true</code>
+	 * @return <code>true</code> if this set contained the specified element.
 	 */
 	public boolean remove(Object o) {
+		boolean contained = contains(o);
+
 		ObjectConnection conn = getObjectConnection();
 		try {
 			Value value = getValue(o);
@@ -214,7 +216,7 @@ public class RemotePropertySet implements PropertySet, Set<Object> {
 		}
 		refresh(o);
 		refresh();
-		return true;
+		return contained;
 	}
 
 	public boolean removeAll(Collection<?> c) {


### PR DESCRIPTION
The problem of `RemotePropertySet.remove()` always returning true - which contradicts the intuition of `Set` - was solved by checking for the element being present beforehand (see Issue #133 ).