### PR TITLE
More convenient context support for transactions

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/ChoiceSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/ChoiceSupport.java
@@ -1,11 +1,19 @@
 package com.github.anno4j.model.impl.multiplicity;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 
+import com.github.anno4j.model.Body;
+import com.github.anno4j.model.impl.ResourceObject;
+import org.apache.commons.io.IOUtils;
+import org.openrdf.repository.RepositoryException;
 import org.openrdf.repository.object.RDFObject;
 
 import com.github.anno4j.annotations.Partial;
 import com.github.anno4j.model.impl.ResourceObjectSupport;
+import org.openrdf.rio.*;
 
 @Partial
 public abstract class ChoiceSupport extends ResourceObjectSupport implements Choice {
@@ -24,6 +32,30 @@ public abstract class ChoiceSupport extends ResourceObjectSupport implements Cho
 
         items.add(item);
         this.setItems(items);
+    }
+
+    @Override
+    public String getTriples(RDFFormat format) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        RDFParser parser = Rio.createParser(RDFFormat.NTRIPLES);
+        RDFWriter writer = Rio.createWriter(format, out);
+        parser.setRDFHandler(writer);
+
+        try {
+            this.getObjectConnection().exportStatements(this.getResource(), null, null, true, writer);
+
+            if(this.getItems() != null) {
+                for(RDFObject item : this.getItems()) {
+                    if(item instanceof ResourceObject) {
+                        parser.parse(IOUtils.toInputStream( ((ResourceObject)item).getTriples(format)), "");
+                    }
+                }
+            }
+        } catch (IOException | RDFHandlerException | RDFParseException | RepositoryException e) {
+            e.printStackTrace();
+        }
+
+        return out.toString();
     }
     
 }

--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/CompositeSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/multiplicity/CompositeSupport.java
@@ -1,11 +1,17 @@
 package com.github.anno4j.model.impl.multiplicity;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.HashSet;
 
+import com.github.anno4j.model.impl.ResourceObject;
+import org.apache.commons.io.IOUtils;
+import org.openrdf.repository.RepositoryException;
 import org.openrdf.repository.object.RDFObject;
 
 import com.github.anno4j.annotations.Partial;
 import com.github.anno4j.model.impl.ResourceObjectSupport;
+import org.openrdf.rio.*;
 
 @Partial
 public abstract class CompositeSupport extends ResourceObjectSupport implements Composite {
@@ -25,5 +31,28 @@ public abstract class CompositeSupport extends ResourceObjectSupport implements 
         items.add(item);
         this.setItems(items);
     }
-    
+
+    @Override
+    public String getTriples(RDFFormat format) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        RDFParser parser = Rio.createParser(RDFFormat.NTRIPLES);
+        RDFWriter writer = Rio.createWriter(format, out);
+        parser.setRDFHandler(writer);
+
+        try {
+            this.getObjectConnection().exportStatements(this.getResource(), null, null, true, writer);
+
+            if(this.getItems() != null) {
+                for(RDFObject item : this.getItems()) {
+                    if(item instanceof ResourceObject) {
+                        parser.parse(IOUtils.toInputStream( ((ResourceObject)item).getTriples(format)), "");
+                    }
+                }
+            }
+        } catch (IOException | RDFHandlerException | RDFParseException | RepositoryException e) {
+            e.printStackTrace();
+        }
+
+        return out.toString();
+    }
 }

--- a/anno4j-core/src/test/java/com/github/anno4j/model/impl/multiplicity/ChoiceTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/model/impl/multiplicity/ChoiceTest.java
@@ -2,10 +2,14 @@ package com.github.anno4j.model.impl.multiplicity;
 
 import com.github.anno4j.Anno4j;
 import com.github.anno4j.model.Annotation;
+import com.github.anno4j.model.Motivation;
+import com.github.anno4j.model.MotivationFactory;
 import com.github.anno4j.model.impl.ResourceObject;
+import com.github.anno4j.model.impl.body.TextualBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.openrdf.repository.RepositoryException;
+import org.openrdf.rio.RDFFormat;
 
 import java.util.List;
 
@@ -63,5 +67,46 @@ public class ChoiceTest {
 
         assertEquals(1, ((Choice) resultAnnotation.getBodies().iterator().next()).getItems().size());
         assertEquals(2, ((Choice) resultAnnotation.getTargets().toArray()[0]).getItems().size());
+    }
+
+    /**
+     * Test was added to cover the issue of a request sent by email.
+     * Issue concerned the not printing of the items contained in a Choice object.
+     *
+     * Test is kept until the functionality is tested more thoroughly.
+     */
+    @Test
+    public void testPrintingChoiceItems() throws RepositoryException, IllegalAccessException, InstantiationException {
+
+        Annotation annotation = this.anno4j.createObject(Annotation.class);
+
+        Choice choice = anno4j.createObject(Choice.class);
+
+        TextualBody txtBody1 = anno4j.createObject(TextualBody.class);
+
+        Motivation taggingMotivation = MotivationFactory.getTagging(anno4j);
+
+        txtBody1.addPurpose(taggingMotivation);
+        txtBody1.setValue("love");
+
+        TextualBody txtBody12 = anno4j.createObject(TextualBody.class);
+
+        Motivation taggingMotivation2 = MotivationFactory.getTagging(anno4j);
+
+        txtBody12.addPurpose(taggingMotivation2);
+        txtBody12.setValue("love2222");
+        choice.addItem(txtBody1);
+        choice.addItem(txtBody12);
+
+        TextualBody txtBody13 = anno4j.createObject(TextualBody.class);
+
+        Motivation taggingMotivation3 = MotivationFactory.getTagging(anno4j);
+
+        txtBody13.addPurpose(taggingMotivation3);
+        txtBody13.setValue("love333333");
+        annotation.addBody(txtBody13);
+        annotation.addBody(choice);
+
+        System.out.println(annotation.getTriples(RDFFormat.RDFXML));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,15 @@
         </developer>
         <developer>
             <name>Emanuel Berndl</name>
-            <email>emanuel.berndl@gmail.com</email>
+            <email>berndl.emanuel@gmail.com</email>
+        </developer>
+        <developer>
+            <name>Thomas Weißgerber</name>
+            <email>weissger@posteo.de</email>
+        </developer>
+        <developer>
+            <name>Matthias Fisch</name>
+            <email>github@matthias-fisch.de</email>
         </developer>
     </developers>
 


### PR DESCRIPTION
The `Anno4j` class now features a `createTransaction(URI context)` method (see Issue #140 and #141 )