### PR TITLE
Parsing of generic ResourceObjects with ObjectParser.

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/io/ObjectParser.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/io/ObjectParser.java
@@ -2,6 +2,7 @@ package com.github.anno4j.io;
 
 import com.github.anno4j.Anno4j;
 import com.github.anno4j.model.Annotation;
+import com.github.anno4j.model.impl.ResourceObject;
 import com.github.anno4j.model.namespaces.OADM;
 import com.github.anno4j.model.namespaces.RDF;
 import org.openrdf.model.impl.StatementImpl;
@@ -19,7 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -28,13 +29,16 @@ import java.util.List;
  */
 public class ObjectParser {
 
+    /**
+     * The Anno4j object that receives the parsed triples.
+     */
     private Anno4j anno4j;
 
     /**
      * Basic constructor, which sets up all the necessary repositories.
      *
-     * @throws RepositoryException
-     * @throws RepositoryConfigException
+     * @throws RepositoryException Thrown if an error occurred accessing the created repository.
+     * @throws RepositoryConfigException Thrown if an error occurred configuring the new repository.
      */
     public ObjectParser() throws RepositoryException, RepositoryConfigException {
         this.anno4j = new Anno4j();
@@ -91,50 +95,79 @@ public class ObjectParser {
      * objects.
      * Does also call the clear() method, which removes all statements from the local Anno4j instance.
      *
-     * @throws RepositoryException
+     * @throws RepositoryException Thrown if an error occurs while accessing the repository.
      */
     public void shutdown() throws RepositoryException, UpdateExecutionException {
-//        Add anno4j shutdown method here.
+        // Add anno4j shutdown method here.
         this.clear();
         this.anno4j.getObjectRepository().getConnection().close();
         this.anno4j.getRepository().getConnection().close();
     }
 
     /**
-     * Method to return all annotations that have been parsed with this
-     * ObjectParser.
-     *
-     * @return A list of annotations, created by parsing (different)
-     * serializations of annotations.
+     * Returns all instances of the given type (and its subtypes) that are present in this parsers Anno4j instance.
+     * The result of this method call isn't guaranteed to be unique and may contain duplicates.
+     * @param type An {@link org.openrdf.annotations.Iri}-annotated type that all returned objects must have.
+     * @param <T> The type of the returned objects.
+     * @return Returns all instances present in the Anno4j connected triplestore having the given {@code type}. This
+     * result may contain duplicates.
+     * @throws RepositoryException Thrown if an error occurs accessing the connected triplestore.
      */
-    private List<Annotation> getAnnotations() {
-
-        List<Annotation> results = new LinkedList<>();
+    private <T extends ResourceObject> List<T> getInstancesOfType(Class<? extends T> type) throws RepositoryException {
+        List<T> instances = new ArrayList<>();
+        ObjectConnection connection = anno4j.getObjectRepository().getConnection();
 
         try {
-            results = anno4j.getObjectRepository().getConnection().getObjects(Annotation.class).asList();
-        } catch (QueryEvaluationException | RepositoryException e) {
-            e.printStackTrace();
+            instances.addAll(connection.getObjects(type).asList());
+        } catch (QueryEvaluationException e) {
+            throw new RepositoryException(e);
         }
 
-        return results;
+        return instances;
     }
 
     /**
-     * Used to parse a given text content, supported in a given serialization
-     * format.
-     * The Annotations are then returned as a list.
-     * For performance reasons, the local memorystore can be cleared by defining the boolean parameter as true,
-     * which is the standard behaviour.
+     * Used to parse {@link Annotation}-objects from a the RDF-document supplied.
+     * All annotations found are returned as a list.
+     * For performance reasons, the local memorystore can be cleared by defining the boolean parameter as true.
+     * <br>
+     * <b>Note:</b> This method is supported for legacy purposes. In order to parse resource objects of any type use
+     * the more general method {@link #parse(Class, String, URL, RDFFormat, boolean)}.
      *
      * @param content     The String representation of the textcontent.
      * @param documentURL The basic URL used for namespaces.
      * @param format      The format of the given serialization. Needs to be
      *                    supported of an instance of RDFFormat.
      * @param clear       Determines, if the local Anno4j instance should be cleared or not after a call to parse().
-     * @return A list of annotations
+     * @return The annotations contained in the given RDF-document or an empty list if an error occurred.
      */
     public List<Annotation> parse(String content, URL documentURL, RDFFormat format, boolean clear) {
+        try {
+            return parse(Annotation.class, content, documentURL, format, clear);
+
+        } catch (RepositoryException | RDFParseException e) {
+            e.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     *
+     * @param type An {@link org.openrdf.annotations.Iri}-annotated type that all returned objects must have.
+     * @param content The RDF-serialization to read from. This must be in the format specified by {@code format}.
+     * @param documentURL The base URL used for namespaces.
+     * @param format The format of the given RDF-serialization.
+     * @param clear Determines, if the local Anno4j instance should be cleared or not after a call to parse().
+     *              This can be set to increase performance.
+     * @param <T> The type of the returned objects.
+     * @return Returns all resources having the given type as their {@code rdf:type}. This result will also contain
+     * all objects parsed since the underlying Anno4j instance was last cleared.
+     * @throws RepositoryException Thrown if an error occurred accessing the connected triplestore of the underlying
+     * Anno4j instance.
+     * @throws RDFParseException Thrown if an error occurs while parsing the RDF-document.
+     */
+    public <T extends ResourceObject> List<T> parse(Class<? extends T> type, String content, URL documentURL, RDFFormat format, boolean clear) throws RepositoryException, RDFParseException {
+        // Parse the document using RIO parser. All read statements will be inserted into the Anno4j connected triplestore:
         RDFParser parser = Rio.createParser(format);
         try {
             StatementSailHandler handler = new StatementSailHandler(this.anno4j.getRepository().getConnection());
@@ -143,21 +176,22 @@ public class ObjectParser {
             try (InputStream stream = new ByteArrayInputStream(bytes)) {
                 parser.parse(stream, documentURL.toString());
             }
-        } catch (RDFHandlerException | RDFParseException | IOException | RepositoryException e) {
-            e.printStackTrace();
+        } catch (RDFHandlerException | IOException e) {
+            throw new RDFParseException(e);
         }
 
-        List<Annotation> annotations = getAnnotations();
+        // Get the instances of the requested type:
+        List<T> instances = getInstancesOfType(type);
 
         // Possibly clear all triples in the triplestore:
         if (clear) {
             try {
                 clear();
-            } catch (RepositoryException | UpdateExecutionException e) {
-                e.printStackTrace();
+            } catch (UpdateExecutionException e) {
+                throw new RepositoryException(e);
             }
         }
 
-        return annotations;
+        return instances;
     }
 }

--- a/anno4j-core/src/test/java/com/github/anno4j/io/ObjectParserTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/io/ObjectParserTest.java
@@ -3,9 +3,9 @@ package com.github.anno4j.io;
 import com.github.anno4j.model.Annotation;
 import com.github.anno4j.model.Body;
 import com.github.anno4j.model.Target;
+import com.github.anno4j.model.impl.ResourceObject;
 import com.github.anno4j.model.namespaces.DCTYPES;
 import com.github.anno4j.model.namespaces.RDF;
-import com.github.anno4j.io.ObjectParser;
 import org.junit.Test;
 import org.openrdf.annotations.Iri;
 import org.openrdf.query.UpdateExecutionException;
@@ -16,15 +16,30 @@ import org.openrdf.rio.RDFFormat;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Testsuite testing the {@link ObjectParser} class.
  */
 public class ObjectParserTest {
+
+    /**
+     * Returns the URIs of the given resource objects (cf. {@link ResourceObject#getResourceAsString()}).
+     * @param resources The resources for which to get an URI.
+     * @return Returns the URIs of the given resources.
+     */
+    private static Collection<String> getResourcesAsStrings(Collection<? extends ResourceObject> resources) {
+        Collection<String> uris = new LinkedList<>();
+        for(ResourceObject resource : resources) {
+            uris.add(resource.getResourceAsString());
+        }
+        return uris;
+    }
 
     @Test
     public void testJSONLD() throws UpdateExecutionException {
@@ -109,6 +124,34 @@ public class ObjectParserTest {
         } catch (IOException | RepositoryException | RepositoryConfigException e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void testGenericParsing() throws Exception {
+        URL url = new URL("http://example.com/");
+        ObjectParser parser = new ObjectParser();
+
+        // Get all dctype:Sound resources:
+        List<Sound> sounds = parser.parse(Sound.class, TURTLE_MULTIPLE, url, RDFFormat.TURTLE, true);
+        assertEquals(3, sounds.size());
+        Collection<String> uris = getResourcesAsStrings(sounds);
+        assertTrue(uris.contains("http://www.example.com/ns#body3"));
+        assertTrue(uris.contains("http://www.example.com/ns#body4"));
+        assertTrue(uris.contains("http://www.example.com/ns#body5"));
+
+        // Get all resources:
+        List<ResourceObject> resources = parser.parse(ResourceObject.class, TURTLE_MULTIPLE, url, RDFFormat.TURTLE, true);
+        assertEquals(9, resources.size());
+        uris = getResourcesAsStrings(resources);
+        assertTrue(uris.contains("http://www.example.com/ns#anno3"));
+        assertTrue(uris.contains("http://www.example.com/ns#body3"));
+        assertTrue(uris.contains("http://www.example.com/ns#target3"));
+        assertTrue(uris.contains("http://www.example.com/ns#anno4"));
+        assertTrue(uris.contains("http://www.example.com/ns#body4"));
+        assertTrue(uris.contains("http://www.example.com/ns#target4"));
+        assertTrue(uris.contains("http://www.example.com/ns#anno5"));
+        assertTrue(uris.contains("http://www.example.com/ns#body5"));
+        assertTrue(uris.contains("http://www.example.com/ns#target5"));
     }
 
     /**


### PR DESCRIPTION
The ObjectParser was limited to the `Annotation`-type only. The new implementation allows parsing of generic `ResourceObject`s using the new method `parse(Class, String, URL, RDFFormat, boolean)`.
The old method for parsing `Annotation`s was preserved to ensure compatibility, but rewritten to use the new generic implementation.
In order to keep the old implementation compatible the new one also doesn't guarantee that the result is duplicate-free.

Example usage:
```java
ObjectParser parser = new ObjectParser();
// Specify the type to get all instances of it:
List<Person> persons = parser.parse(Person.class, doc, baseUri, RDFFormat.TURTLE, true);

// Use ResourceObject to get all resources in the document:
List<ResourceObject> allResources = parser.parse(ResourceObject.class, doc, baseUri, RDFFormat.TURTLE, true);
```