### PR TITLE
Casting and instance checks in ResourceObjectSupport.

### DIFF
--- a/anno4j-core/src/test/java/com/github/anno4j/model/impl/ResourceObjectSupportTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/model/impl/ResourceObjectSupportTest.java
@@ -1,0 +1,68 @@
+package com.github.anno4j.model.impl;
+
+import com.github.anno4j.Anno4j;
+import com.github.anno4j.model.Annotation;
+import org.junit.Before;
+import org.junit.Test;
+import org.openrdf.annotations.Iri;
+import org.openrdf.model.Resource;
+
+/**
+ * Test for {@link ResourceObjectSupport}.
+ * Tests for instance checking and casting are implemented in {@link SpecialAnnotationSupport}.
+ */
+public class ResourceObjectSupportTest {
+
+    /**
+     * Subtype of the OADM annotation which provides a testing method.
+     */
+    @Iri("http://example.de/special_annotation")
+    public interface SpecialAnnotation extends Annotation {
+
+        /**
+         * Tests {@link ResourceObjectSupport#isInstance(Resource)} and {@link ResourceObjectSupport#isInstance(Class)}.
+         * Is implemented in {@link SpecialAnnotationSupport} because these tests must be run inside a support class.
+         */
+        void testTypeChecking() throws Exception;
+
+        /**
+         * Tests {@link ResourceObjectSupport#cast(Class)}.
+         * Is implemented in {@link SpecialAnnotationSupport} because these tests must be run inside a support class.
+         */
+        void testCasting() throws Exception;
+    }
+
+    /**
+     * Subtype of the testing annotation for testing down-casts.
+     */
+    @Iri("http://example.de/very_special_annotation")
+    public interface VerySpecialAnnotation extends SpecialAnnotation {
+    }
+
+    /**
+     * The resource object used for testing.
+     */
+    private VerySpecialAnnotation annotation;
+
+    @Before
+    public void setUp() throws Exception {
+        Anno4j anno4j = new Anno4j();
+        annotation = anno4j.createObject(VerySpecialAnnotation.class);
+    }
+
+    /**
+     * Tests instance checking and casting.
+     */
+    @Test
+    public void testTypeChecking() throws Exception {
+        annotation.testTypeChecking();
+    }
+
+    /**
+     * Tests instance checking and casting.
+     */
+    @Test
+    public void testCasting() throws Exception {
+        annotation.testCasting();
+    }
+}

--- a/anno4j-core/src/test/java/com/github/anno4j/model/impl/SpecialAnnotationSupport.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/model/impl/SpecialAnnotationSupport.java
@@ -1,0 +1,53 @@
+package com.github.anno4j.model.impl;
+
+import com.github.anno4j.annotations.Partial;
+import com.github.anno4j.model.Annotation;
+import com.github.anno4j.model.AnnotationSupport;
+import com.github.anno4j.model.CreationProvenance;
+import com.github.anno4j.model.impl.agent.Person;
+import com.github.anno4j.model.namespaces.OADM;
+import org.openrdf.model.impl.URIImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Partial class used for {@link ResourceObjectSupportTest} tests that must be run inside a support class.
+ */
+@Partial
+public abstract class SpecialAnnotationSupport extends AnnotationSupport implements ResourceObjectSupportTest.SpecialAnnotation {
+
+    @Override
+    public void testTypeChecking() throws Exception {
+        assertTrue(isInstance(Annotation.class));
+        assertTrue(isInstance(new URIImpl(OADM.ANNOTATION)));
+        assertTrue(isInstance(CreationProvenance.class));
+        assertTrue(isInstance(ResourceObject.class));
+        assertFalse(isInstance(Person.class));
+    }
+
+    @Override
+    public void testCasting() throws Exception {
+        // Test up-cast:
+        Annotation annotation = cast(Annotation.class);
+        assertEquals(getResourceAsString(), annotation.getResourceAsString());
+        CreationProvenance provenance = cast(CreationProvenance.class);
+        assertEquals(getResourceAsString(), provenance.getResourceAsString());
+        ResourceObject resourceObject = cast(ResourceObject.class);
+        assertEquals(getResourceAsString(), resourceObject.getResourceAsString());
+
+        // Test downcast:
+        ResourceObjectSupportTest.VerySpecialAnnotation verySpecialAnnotation = cast(ResourceObjectSupportTest.VerySpecialAnnotation.class);
+        assertEquals(getResourceAsString(), verySpecialAnnotation.getResourceAsString());
+
+        // Test wrong type cast:
+        boolean exceptionThrown = false;
+        try {
+            cast(Person.class);
+        } catch (ClassCastException ignored) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+    }
+}


### PR DESCRIPTION
Implemented some convenience methods in `ResourceObjectSupport` that make the handling of the resource object easier.
1. Methods for instance checks were implemented. With these methods you can check whether the resource object the support class belongs to is instance of a certain RDFS/OWL class. This way you don't need to retrieve the `ResourceObject` via `ObjectConnection` and then check types with Java's `instanceof`.
Example:
```java
@Override
public void mySupportMethod() {
      if(isInstance(Annotation.class)) {
          // Do something...
     }
}
```
2. A method `cast` with which the resource can be retrieved in any type of the inheritance hierarchy. This way down-casts are possible even if the Java representation of the resource doesn't represent the type. To ensure type safety first a check with `isInstance()` is performed.
```java
// E.g. inside CreationProvenanceSupport - Do down-cast:
try {
      Annotation thisAsAnnotation = cast(Annotation.class);
     // Work with annotation methods...
} catch(ClassCastException e) {
    System.out.println("This is only a CreationProvenance object :(");
}
```