### PR TITLE
Respect max. cardinalities and functionality when generating method stubs

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/schema_parsing/building/support/InterfaceTypeSpecSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/schema_parsing/building/support/InterfaceTypeSpecSupport.java
@@ -62,8 +62,11 @@ public abstract class InterfaceTypeSpecSupport extends ClazzBuildingSupport impl
 
             // Don't generate methods for properties from OWL, RDFS...:
             if(!isFromSpecialVocabulary(property)) {
-                // Only add the method to the type spec if it was not already defined in a superclass:
-                if(!isDefinedInSuperclass(property)) {
+                // Only add the method to the type spec if it was not already defined in a superclass
+                // and if it can have values for this class:
+                Integer maxCardinality = buildable.getMaximumCardinality(this);
+                if(!isDefinedInSuperclass(property) && (maxCardinality == null || maxCardinality > 0)) {
+
                     getters.add(buildable.buildGetter(this, config));
                     setters.add(buildable.buildSetter(this, config));
                     setters.add(buildable.buildVarArgSetter(this, config));

--- a/anno4j-core/src/main/java/com/github/anno4j/schema_parsing/building/support/PropertyBuildingSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/schema_parsing/building/support/PropertyBuildingSupport.java
@@ -219,14 +219,14 @@ public abstract class PropertyBuildingSupport extends PropertySchemaAnnotationSu
 
     /**
      * Returns whether the property has a single value in the given context.
-     * This is the case if the property has a cardinality of one.
+     * This is the case if the property has a (maximum) cardinality of one.
      * @param domainClazz The class defining the context.
      * @return Returns true iff the setter should have a single value parameter.
      * @throws RepositoryException Thrown if an error occurs while querying the repository.
      */
     boolean isSingleValueProperty(RDFSClazz domainClazz) throws RepositoryException {
-        Integer cardinality = getCardinality(domainClazz);
-        return cardinality != null && cardinality == 1;
+        Integer maximumCardinality = getMaximumCardinality(domainClazz);
+        return maximumCardinality != null && maximumCardinality == 1;
     }
 
     /**

--- a/anno4j-core/src/main/java/com/github/anno4j/schema_parsing/model/BuildableRDFSProperty.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/schema_parsing/model/BuildableRDFSProperty.java
@@ -27,8 +27,22 @@ public interface BuildableRDFSProperty extends RDFSProperty, BuildableOntologyPr
 
     /**
      * Returns the cardinality set for the property declared at the given class.
+     * The cardinality can be specified explicitly through {@code owl:cardinality} or implicitly
+     * through {@code owl:minCardinality} and {@code owl:maxCardinality} with the same value.
+     * @param domainClazz The class for which to retrieve the cardinality.
      * @return Returns the cardinality or null if there is no fixed cardinality set.
      * @throws RepositoryException Thrown if an error occurs while querying the repository.
      */
     Integer getCardinality(RDFSClazz domainClazz) throws RepositoryException;
+
+    /**
+     * Returns the maximum cardinality of the property declared at the given class.
+     * The maximum cardinality can be specified explicitly through {@code owl:maxCardinality} or
+     * implicitly through a fixed cardinality ({@code owl:cardinality}).
+     * @param domainClazz The class for which to retrieve the minimum cardinality.
+     * @return Returns the cardinality or null if there is no upper bound on the cardinality of this property
+     * in context of the given class.
+     * @throws RepositoryException Thrown if an error occurs while querying the repository.
+     */
+    Integer getMaximumCardinality(RDFSClazz domainClazz) throws RepositoryException;
 }

--- a/anno4j-core/src/test/java/com/github/anno4j/model/impl/ResourceObjectSupportTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/model/impl/ResourceObjectSupportTest.java
@@ -1,0 +1,68 @@
+package com.github.anno4j.model.impl;
+
+import com.github.anno4j.Anno4j;
+import com.github.anno4j.model.Annotation;
+import org.junit.Before;
+import org.junit.Test;
+import org.openrdf.annotations.Iri;
+import org.openrdf.model.Resource;
+
+/**
+ * Test for {@link ResourceObjectSupport}.
+ * Tests for instance checking and casting are implemented in {@link SpecialAnnotationSupport}.
+ */
+public class ResourceObjectSupportTest {
+
+    /**
+     * Subtype of the OADM annotation which provides a testing method.
+     */
+    @Iri("http://example.de/special_annotation")
+    public interface SpecialAnnotation extends Annotation {
+
+        /**
+         * Tests {@link ResourceObjectSupport#isInstance(Resource)} and {@link ResourceObjectSupport#isInstance(Class)}.
+         * Is implemented in {@link SpecialAnnotationSupport} because these tests must be run inside a support class.
+         */
+        void testTypeChecking() throws Exception;
+
+        /**
+         * Tests {@link ResourceObjectSupport#cast(Class)}.
+         * Is implemented in {@link SpecialAnnotationSupport} because these tests must be run inside a support class.
+         */
+        void testCasting() throws Exception;
+    }
+
+    /**
+     * Subtype of the testing annotation for testing down-casts.
+     */
+    @Iri("http://example.de/very_special_annotation")
+    public interface VerySpecialAnnotation extends SpecialAnnotation {
+    }
+
+    /**
+     * The resource object used for testing.
+     */
+    private VerySpecialAnnotation annotation;
+
+    @Before
+    public void setUp() throws Exception {
+        Anno4j anno4j = new Anno4j();
+        annotation = anno4j.createObject(VerySpecialAnnotation.class);
+    }
+
+    /**
+     * Tests instance checking and casting.
+     */
+    @Test
+    public void testTypeChecking() throws Exception {
+        annotation.testTypeChecking();
+    }
+
+    /**
+     * Tests instance checking and casting.
+     */
+    @Test
+    public void testCasting() throws Exception {
+        annotation.testCasting();
+    }
+}

--- a/anno4j-core/src/test/java/com/github/anno4j/model/impl/SpecialAnnotationSupport.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/model/impl/SpecialAnnotationSupport.java
@@ -1,0 +1,53 @@
+package com.github.anno4j.model.impl;
+
+import com.github.anno4j.annotations.Partial;
+import com.github.anno4j.model.Annotation;
+import com.github.anno4j.model.AnnotationSupport;
+import com.github.anno4j.model.CreationProvenance;
+import com.github.anno4j.model.impl.agent.Person;
+import com.github.anno4j.model.namespaces.OADM;
+import org.openrdf.model.impl.URIImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Partial class used for {@link ResourceObjectSupportTest} tests that must be run inside a support class.
+ */
+@Partial
+public abstract class SpecialAnnotationSupport extends AnnotationSupport implements ResourceObjectSupportTest.SpecialAnnotation {
+
+    @Override
+    public void testTypeChecking() throws Exception {
+        assertTrue(isInstance(Annotation.class));
+        assertTrue(isInstance(new URIImpl(OADM.ANNOTATION)));
+        assertTrue(isInstance(CreationProvenance.class));
+        assertTrue(isInstance(ResourceObject.class));
+        assertFalse(isInstance(Person.class));
+    }
+
+    @Override
+    public void testCasting() throws Exception {
+        // Test up-cast:
+        Annotation annotation = cast(Annotation.class);
+        assertEquals(getResourceAsString(), annotation.getResourceAsString());
+        CreationProvenance provenance = cast(CreationProvenance.class);
+        assertEquals(getResourceAsString(), provenance.getResourceAsString());
+        ResourceObject resourceObject = cast(ResourceObject.class);
+        assertEquals(getResourceAsString(), resourceObject.getResourceAsString());
+
+        // Test downcast:
+        ResourceObjectSupportTest.VerySpecialAnnotation verySpecialAnnotation = cast(ResourceObjectSupportTest.VerySpecialAnnotation.class);
+        assertEquals(getResourceAsString(), verySpecialAnnotation.getResourceAsString());
+
+        // Test wrong type cast:
+        boolean exceptionThrown = false;
+        try {
+            cast(Person.class);
+        } catch (ClassCastException ignored) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+    }
+}

--- a/anno4j-core/src/test/java/com/github/anno4j/schema_parsing/building/OWLPropertySpecTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/schema_parsing/building/OWLPropertySpecTest.java
@@ -62,6 +62,7 @@ public class OWLPropertySpecTest {
         BuildableRDFSClazz dish = anno4j.findByID(BuildableRDFSClazz.class, "http://example.de/ont#Dish");
         BuildableRDFSProperty nameProperty = anno4j.findByID(BuildableRDFSProperty.class, "http://example.de/ont#name");
         BuildableRDFSProperty servesProperty = anno4j.findByID(BuildableRDFSProperty.class, "http://example.de/ont#serves");
+        BuildableRDFSProperty isOrganicProperty = anno4j.findByID(BuildableRDFSProperty.class, "http://example.de/ont#is_organic");
 
         // Build the getter method signature:
         MethodSpec nameGetter = nameProperty.buildGetter(restaurant, generationConfig);
@@ -81,6 +82,16 @@ public class OWLPropertySpecTest {
         assertEquals("getServes", servesGetter.name);
         ClassName setType = ClassName.get(Set.class);
         assertEquals(ParameterizedTypeName.get(setType, dish.getJavaPoetClassName(generationConfig)), servesGetter.returnType);
+
+        // Build the getter method signature:
+        MethodSpec isOrganicGetter = isOrganicProperty.buildGetter(dish, generationConfig);
+
+        assertEquals(2, isOrganicGetter.annotations.size());
+        assertEquals(0, isOrganicGetter.parameters.size());
+        assertEquals("getIsOrganic", isOrganicGetter.name);
+
+        // The cardinality of the property is one, so there should be a single value return type:
+        assertEquals(ClassName.get(Boolean.class), isOrganicGetter.returnType);
     }
 
     @Test

--- a/anno4j-core/src/test/resources/restaurant_owl.ttl
+++ b/anno4j-core/src/test/resources/restaurant_owl.ttl
@@ -61,7 +61,13 @@ ex:has_main_dish a owl:FunctionalProperty ;
 		  rdfs:subPropertyOf ex:contains ;
 		  rdfs:label "hat Hauptgang"@de;
 		  rdfs:label "has main dish"@en .
-		  
+
+ex:is_organic a owl:DatatypeProperty ;
+          rdfs:domain ex:Dish ;
+          rdfs:range xsd:boolean ;
+          rdfs:label "ist vegetarisch"@de ;
+          rdfs:label "is organic"@en .
+
 ex:isMainDishOf a owl:InverseFunctionalProperty ;
 		 rdfs:subPropertyOf ex:isContainedIn ;
 		 rdfs:label "ist Hauptgang von"@de ;
@@ -122,3 +128,8 @@ ex:PartialItalianMenu rdfs:subClassOf _:r7 ;
 _:r7 	a owl:Restriction ;
 		owl:onProperty ex:contains ;
 		owl:someValuesFrom ex:ItalianDish .
+
+ex:Dish rdfs:subClassOf _:r8 .
+_:r8    a owl:Restriction ;
+	    owl:onProperty ex:is_organic ;
+		owl:maxCardinality "1"^^xsd:unsignedInt .


### PR DESCRIPTION
The current implementation of `OWLJavaFileGenerator` generated the return-type/parameter-type of getters/setters respectively mapping properties with a `owl:maxCardinality`-restriction of one as `Set`. This is somewhat unintuitive.
This bugfix introduces several improvements on how the `OWLJavaFileGenerator` handles cardinalities:

- Property-methods which properties have a `owl:maxCardinality` restriction of `1` for the respective class now have a single valued return-type/parameter-type
- Property-methods which properties are functional now have a single valued return-type/parameter-type.
- Getters/setters are not generated if the respective property is restricted to `0` in context of the generated class 


For example the property `ecrm:P48_has_preferred_identifier` is now generated in `E1CRMEntity ` as:
```java
@Iri("http://erlangen-crm.org/current/P48_has_preferred_identifier")
@MaxCardinality(1)
@SubPropertyOf({"http://erlangen-crm.org/current/P1_is_identified_by"})
@InverseOf({"http://erlangen-crm.org/current/P48i_is_preferred_identifier_of"})
E42Identifier getP48HasPreferredIdentifier();
````