### PR TITLE
Instead of printing stack trace, throw an exception

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/model/AnnotationSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/AnnotationSupport.java
@@ -165,7 +165,7 @@ public abstract class AnnotationSupport extends CreationProvenanceSupport implem
             parser.parse(IOUtils.toInputStream(sb.toString()), "");
 
         } catch (IOException | RDFHandlerException | RDFParseException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         return out.toString();
@@ -234,7 +234,7 @@ public abstract class AnnotationSupport extends CreationProvenanceSupport implem
             // explicitly removing the rdf type triple from the repository
             connection.remove(getResource(), null, null);
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
We'd want the users of this API to get an exception if something goes wrong