### PR TITLE
Map blank nodes to unique URIs when converting to Sesame triples

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/util/JenaSesameUtils.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/util/JenaSesameUtils.java
@@ -42,7 +42,7 @@ public class JenaSesameUtils {
             return asSesameURI(theRes.as(Property.class));
         }
         else {
-            return FACTORY.createBNode(theRes.getId().getLabelString());
+            return FACTORY.createURI("urn:anno4j:" + theRes.getId().getLabelString());
         }
     }
 


### PR DESCRIPTION
I adopted the `JenaSesameUtils` such that all blank nodes in Jena triples are mapped to special URNs. This is necessary when inserting into Anno4j's repository directly, because it is also done by Anno4j itself (via `IDGeneratorAnno4jURN` by default) and thus the naming scheme is expected by other parts of the library. Otherwise problems like the one mentioned in issue #164 can occur when generating sources.