### PR TITLE
Querying of most specific concept(s) by IRI.

### DIFF
--- a/anno4j-core/src/test/java/com/github/anno4j/io/InputOutputTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/io/InputOutputTest.java
@@ -9,7 +9,6 @@ import com.github.anno4j.model.impl.body.TextualBody;
 import com.github.anno4j.model.impl.targets.SpecificResource;
 import com.github.anno4j.model.namespaces.DCTYPES;
 import com.github.anno4j.model.namespaces.RDF;
-import com.github.anno4j.querying.QueryService;
 import org.apache.marmotta.ldpath.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
@@ -208,7 +207,7 @@ public class InputOutputTest {
             " \"@id\": \"http://example.org/anno1\" , \n" +
             " \"@type\":\"oa:Annotation\" , \n" +
 //            " \"oa:motivatedBy\": { \"@id\" : \"oa:describing\" } , \n" +
-            " \"motivation\" : \"oa:describing\" , \n" +
+            " \"motivation\" : { \"@id\" : \"oa:describing\", \"@type\": \"oa:Motivation\" } , \n" +
             " \"body\": { \n" +
             " \"@id\":\"http://example.org/body1\", \n" +
             " \"@type\":\"dctypes:Sound\", \n" +

--- a/anno4j-core/src/test/java/com/github/anno4j/querying/ConceptQueryTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/querying/ConceptQueryTest.java
@@ -1,0 +1,109 @@
+package com.github.anno4j.querying;
+
+import com.github.anno4j.Anno4j;
+import com.github.anno4j.model.impl.ResourceObject;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+import org.openrdf.annotations.Iri;
+import org.openrdf.repository.sail.SailRepository;
+import org.openrdf.rio.RDFFormat;
+import org.openrdf.sail.memory.MemoryStore;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link com.github.anno4j.Anno4j#getConcept(String)} and {@link com.github.anno4j.Anno4j#getConcepts(String)}.
+ */
+public class ConceptQueryTest {
+
+    /*
+    Ontology for testing:
+
+                    ex:Vehicle        ex:House
+                        |                |
+                 -----------------       |
+                /       |         \     /
+             ex:Car   ex:Truck    ex:Camper
+                 |
+            ex:Cabrio
+     */
+
+    @Iri("http://example.org/v2/House")
+    private interface House extends ResourceObject { }
+
+    @Iri("http://example.org/v2/Vehicle")
+    private interface Vehicle extends ResourceObject { }
+
+    @Iri("http://example.org/v2/Car")
+    private interface Car extends Vehicle { }
+
+    @Iri("http://example.org/v2/Truck")
+    private interface Truck extends Vehicle { }
+
+    @Iri("http://example.org/v2/Cabrio")
+    private interface Cabrio extends Car { }
+
+    @Iri("http://example.org/v2/Camper")
+    private interface Camper extends Vehicle, House { }
+
+    /**
+     * Inheritance tree of the above classes and some instances in TTL syntax:
+     */
+    private static final String ONTOLOGY_RDFS_TURTLE =
+            "@prefix ex: <http://example.org/v2/> . " +
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . " +
+            // Taxonomy:
+            "ex:Car rdfs:subClassOf ex:Vehicle . " +
+            "ex:Truck rdfs:subClassOf ex:Vehicle . " +
+            "ex:Camper rdfs:subClassOf ex:Vehicle, ex:House . " +
+            "ex:Cabrio rdfs:subClassOf ex:Car . " +
+            // Instances:
+            "ex:r8spyder a ex:Cabrio, ex:Car, ex:Vehicle . " +
+            "ex:golf a ex:Car, ex:Vehicle . " +
+            "ex:t5 a ex:Car, ex:Truck, ex:Vehicle . " +
+            "ex:vario a ex:Camper, ex:Vehicle, ex:House . ";
+
+
+    @Test
+    public void testGetConcept() throws Exception {
+        // Create an Anno4j object and load the ontology information:
+        Anno4j anno4j = new Anno4j(new SailRepository(new MemoryStore()), null, false);
+        InputStream is = new ByteArrayInputStream(ONTOLOGY_RDFS_TURTLE.getBytes("UTF-8"));
+        anno4j.getRepository().getConnection().add(is, "http://example.org/v2/", RDFFormat.TURTLE);
+
+        // Test resources are mapped to their correct concepts:
+        assertEquals(Cabrio.class, anno4j.getConcept("http://example.org/v2/r8spyder"));
+        assertEquals(Car.class, anno4j.getConcept("http://example.org/v2/golf"));
+        assertEquals(Camper.class, anno4j.getConcept("http://example.org/v2/vario"));
+
+        // Resources with unknown type are mapped to ResourceObject:
+        assertEquals(ResourceObject.class, anno4j.getConcept("http://example.org/v2/318i"));
+
+        // Resources with multiple types are mapped to any of them:
+        Class<? extends ResourceObject> t5Concept = anno4j.getConcept("http://example.org/v2/t5");
+        assertTrue(t5Concept.equals(Car.class) || t5Concept.equals(Truck.class));
+    }
+
+    @Test
+    public void testGetConcepts() throws Exception {
+        // Create an Anno4j object and load the ontology information:
+        Anno4j anno4j = new Anno4j(new SailRepository(new MemoryStore()), null, false);
+        InputStream is = new ByteArrayInputStream(ONTOLOGY_RDFS_TURTLE.getBytes("UTF-8"));
+        anno4j.getRepository().getConnection().add(is, "http://example.org/v2/", RDFFormat.TURTLE);
+
+        // Test resources are mapped to their correct concepts:
+        assertEquals(Sets.<Class<?>>newHashSet(Cabrio.class), anno4j.getConcepts("http://example.org/v2/r8spyder"));
+        assertEquals(Sets.<Class<?>>newHashSet(Car.class), anno4j.getConcepts("http://example.org/v2/golf"));
+        assertEquals(Sets.<Class<?>>newHashSet(Camper.class), anno4j.getConcepts("http://example.org/v2/vario"));
+
+        // Resources with unknown type are mapped to ResourceObject:
+        assertEquals(Sets.<Class<?>>newHashSet(ResourceObject.class), anno4j.getConcepts("http://example.org/v2/318i"));
+
+        // Test resource with multiple specific types:
+        assertEquals(Sets.<Class<?>>newHashSet(Car.class, Truck.class), anno4j.getConcepts("http://example.org/v2/t5"));
+    }
+}


### PR DESCRIPTION
The `Anno4j` class now features two new methods that can be used to determine a Java type for a IRI.
- `getConcepts(String iri)`: Returns all most specific concepts of the resource identified by `iri`. This can be used when working with ontologies that don't define a concept name for some type combinations.
- `getConcept(String iri)`: Returns the `Class<? extends ResourceObject>` for any most specific concept of the given resource.  This can be used if each concept has a name (and a corresponding Java type). This may be the preferred method when only working with Anno4j and an OWL Lite ontology.