### PR TITLE
Added a convenience-method update() to ResourceObject (see #156).

### DIFF
--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/ResourceObject.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/ResourceObject.java
@@ -47,4 +47,11 @@ public interface ResourceObject extends RDFObject {
     String getResourceAsString();
 
     void delete();
+
+    /**
+     * Refreshes the (possibly) cached values of the properties of this resource and guarantees that subsequent calls to getter-methods
+     * will return current values. Please note that refreshing an object may also affect other objects representing the same resource.
+     * @throws RepositoryException Thrown if an error occurs while loading values from the connected repository.
+     */
+    void update() throws RepositoryException;
 }

--- a/anno4j-core/src/main/java/com/github/anno4j/model/impl/ResourceObjectSupport.java
+++ b/anno4j-core/src/main/java/com/github/anno4j/model/impl/ResourceObjectSupport.java
@@ -269,4 +269,14 @@ public abstract class ResourceObjectSupport implements ResourceObject {
         }
     }
 
+    /**
+     * Refreshes the (possibly) cached values of the properties of this resource and guarantees that subsequent calls to getter-methods
+     * will return current values. Please note that refreshing an object may also affect other objects representing the same resource.
+     * @throws RepositoryException Thrown if an error occurs while loading values from the connected repository.
+     */
+    @Override
+    public void update() throws RepositoryException {
+        ObjectConnection connection = getObjectConnection();
+        connection.refresh(this);
+    }
 }

--- a/anno4j-core/src/test/java/com/github/anno4j/model/impl/ResourceObjectSupportTest.java
+++ b/anno4j-core/src/test/java/com/github/anno4j/model/impl/ResourceObjectSupportTest.java
@@ -3,6 +3,7 @@ package com.github.anno4j.model.impl;
 import com.github.anno4j.Anno4j;
 import com.github.anno4j.io.ObjectParser;
 import com.github.anno4j.model.Annotation;
+import com.github.anno4j.model.impl.agent.Person;
 import org.junit.Before;
 import org.junit.Test;
 import org.openrdf.annotations.Iri;
@@ -20,6 +21,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -208,5 +210,20 @@ public class ResourceObjectSupportTest {
         assertNotNull(parsed.findByID(SpecialAnnotation.class, "http://example.de/h"));
         assertNotNull(parsed.findByID(SpecialAnnotation.class, "http://example.de/i"));
         assertNull(parsed.findByID(SpecialAnnotation.class, "http://example.de/f"));
+    }
+
+    @Test
+    public void testRefreshing() throws Exception {
+        Anno4j anno4j = new Anno4j(new SailRepository(new MemoryStore()), null, false);
+
+        Person a = anno4j.createObject(Person.class, (Resource) new URIImpl("http://example.de/anno1"));
+        a.setMbox("alice@example.org");
+
+        Person b = anno4j.createObject(Person.class, (Resource) new URIImpl("http://example.de/anno1"));
+        b.setMbox("bob@example.org");
+
+        // Refresh the first object and check whether it returns the new value:
+        a.update();
+        assertEquals("bob@example.org", a.getMbox());
     }
 }


### PR DESCRIPTION
When calling a getter method a proxy of type `CachedPropertySet` is returned. This set caches values   of the properties of the resource such that they don't need to be retrieved from the triplestore again.
But this sometimes requires to manually refresh the caches. This can be done by:
```java
ObjectConnection connection = anno4j.getObjectRepository().getObjectConnection();
connection.refresh(someResource);
```
Because this is a bit verbose I implemented a convenience method in `ResourceObject`/`ResourceObjectSupport` that does just that. Now it's possible to simply call:
```java
someResource.update();
```

Although `refresh()` would be a more intuitive name this is not possible, because the `EntityProxy` generated by Alibaba already implements a method `refresh()` that handles refreshing caches internally. So calling the convenience method `refresh()` causes a `StackOverflowException`. But it would be possible to only declare such a method in `ResourceObject` relying on Alibabas implementation. But this could case problems in the future.